### PR TITLE
Patch: Multiple Logs on the same session are overwritten

### DIFF
--- a/Lib/Log/Engine/DatabaseLogger.php
+++ b/Lib/Log/Engine/DatabaseLogger.php
@@ -41,6 +41,7 @@ class DatabaseLogger implements CakeLogInterface{
 	* Write the log to database
 	*/
 	function write($type, $message){
+		$this->Log->create();		
 		$this->Log->save(array(
 			'type' => $type,
 			'message' => $message


### PR DESCRIPTION
If the CakeLog::write() is called more than once, subsequent calls will only update the first log entry. The expected behavior should be to create a new entry for each call to CakeLog::write()
