### PR TITLE
adapted method signature to new PHP strict warning

### DIFF
--- a/Lib/Log/Engine/DatabaseLog.php
+++ b/Lib/Log/Engine/DatabaseLog.php
@@ -15,10 +15,12 @@ CakeLog::config('database', array(
 ));
 
 */
+App::uses('BaseLog', 'Log/Engine');
 App::uses('ClassRegistry', 'Utility');
 App::uses('CakeLogInterface','Log');
 App::uses('Log', 'DatabaseLogger.Model');
-class DatabaseLog implements CakeLogInterface{
+
+class DatabaseLog extends BaseLog {
 	
 	/**
 	* Model name placeholder
@@ -34,6 +36,7 @@ class DatabaseLog implements CakeLogInterface{
 	* Contruct the model class
 	*/
 	function __construct($options = array()){
+		parent::__construct($options);
 		$this->model = isset($options['model']) ? $options['model'] : 'DatabaseLogger.Log';
 		$this->Log = ClassRegistry::init($this->model);
 	}
@@ -48,4 +51,7 @@ class DatabaseLog implements CakeLogInterface{
 			'message' => $message
 		));
 	}
+	
+	
+	
 }

--- a/Model/DatabaseLoggerAppModel.php
+++ b/Model/DatabaseLoggerAppModel.php
@@ -51,16 +51,16 @@ class DatabaseLoggerAppModel extends AppModel {
 	* - last : find last record by created date
 	* @param array of options
 	*/
-	function find($type = 'first', $options = array()){
+	function find($type = 'first', $options = array(), $order = NULL, $recursive = NULL){
 		switch($type){
 		case 'last':
 			$options = array_merge(
 				$options,
 				array('order' => "{$this->alias}.{$this->primaryKey} DESC")
 				);
-			return parent::find('first', $options);    
+			return parent::find('first', $options, $order, $recursive);    
 		default: 
-			return parent::find($type, $options);
+			return parent::find($type, $options, $order, $recursive);
 		}
 	}
 	


### PR DESCRIPTION
PHP >5.4 outputs now by default warnings about incorrect method signatures, such as the one in DatabaseLoggerAppModel:54.

The patch fixes this. I hope it is helpful
Kurt
