### PR TITLE
Tracking User ID, Delete Similar Logs, Save Session Data

### DIFF
--- a/Config/Schema/schema.php
+++ b/Config/Schema/schema.php
@@ -9,18 +9,21 @@ class DatabaseLoggerSchema extends CakeSchema {
 	}
 
 	public $logs = array(
-		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'key' => 'primary'),
+		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'unsigned' => false, 'key' => 'primary'),
 		'type' => array('type' => 'string', 'null' => false, 'default' => null, 'length' => 50, 'key' => 'index', 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
-		'message' => array('type' => 'text', 'null' => false, 'default' => null, 'key' => 'index', 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
+		'message' => array('type' => 'text', 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'ip' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 50, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'hostname' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 50, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'uri' => array('type' => 'string', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 		'refer' => array('type' => 'string', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
+		'user_agent' => array('type' => 'string', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
+		'number' => array('type' => 'integer', 'null' => false, 'default' => '0', 'unsigned' => false),
+		'session_data' => array('type' => 'text', 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
+		'user_id' => array('type' => 'integer', 'null' => true, 'default' => '0', 'unsigned' => false),
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
-			'type' => array('column' => 'type', 'unique' => 0),
-			'message' => array('column' => 'message', 'type' => 'fulltext')
+			'type' => array('column' => 'type', 'unique' => 0)
 		),
 		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_general_ci', 'engine' => 'MyISAM')
 	);

--- a/Controller/DatabaseLoggerAppController.php
+++ b/Controller/DatabaseLoggerAppController.php
@@ -1,4 +1,5 @@
 <?php
+	App::uses('AppController','Controller');
 class DatabaseLoggerAppController extends AppController {
 	protected function dataToNamed($key = 'Search'){
   	$params = is_array($this->request->params['named']) ? $this->request->params['named'] : array();

--- a/Controller/LogsController.php
+++ b/Controller/LogsController.php
@@ -3,8 +3,8 @@ class LogsController extends DatabaseLoggerAppController {
 
 	var $name = 'Logs';
 	var $helpers = array('Time','Icing.Csv');
-	var $paginate = array(
-		'order' => 'Log.id DESC',
+	public $paginate = array(
+		'order' => 'Log.created DESC',
 		'fields' => array(
 			'Log.created',
 			'Log.type',
@@ -14,6 +14,7 @@ class LogsController extends DatabaseLoggerAppController {
 	);
 
 	function admin_index($filter = null) {
+		$this->Paginator->settings = $this->paginate;
 		if(!empty($this->data)){
 			$filter = $this->data['Log']['filter'];
 		}
@@ -22,6 +23,8 @@ class LogsController extends DatabaseLoggerAppController {
 			$this->Log->search($this->request->params['named']),
 			$this->Log->textSearch($filter)
 		);
+
+
 		$this->set('logs',$this->paginate($conditions));
 		$this->set('types', $this->Log->getTypes());
 		$this->set('filter', $filter);

--- a/Controller/LogsController.php
+++ b/Controller/LogsController.php
@@ -9,7 +9,9 @@ class LogsController extends DatabaseLoggerAppController {
 			'Log.created',
 			'Log.type',
 			'Log.message',
-			'Log.id'
+			'Log.id',
+			'Log.user_id'
+
 		)
 	);
 
@@ -67,5 +69,22 @@ class LogsController extends DatabaseLoggerAppController {
 		}
 		$this->Session->setFlash(__('Log was not deleted'));
 		$this->redirect(array('action' => 'index'));
+	}
+
+	public function admin_delete_similar($id = null) {
+		if (!$id) {
+			$this->Session->setFlash(__('Invalid id for log'));
+			$this->redirect(array('action'=>'index'));
+		}
+		$log = $this->Log->findById($id);
+		if ($this->Log->deleteAll(['Log.message LIKE'=>'%'.$log['Log']['message'].'%'])) {
+			$this->Session->setFlash(__('Log deleted'));
+			$this->redirect(array('action'=>'index'));
+		}
+		$this->Session->setFlash(__('Log was not deleted'));
+		$this->redirect(array('action' => 'index'));
+	}
+	public function teste(){
+
 	}
 }

--- a/Model/Log.php
+++ b/Model/Log.php
@@ -9,6 +9,8 @@ class Log extends DatabaseLoggerAppModel {
 		$this->data[$this->alias]['hostname'] = env('HTTP_HOST');
 		$this->data[$this->alias]['uri'] = env('REQUEST_URI');
 		$this->data[$this->alias]['refer'] = env('HTTP_REFERER');
+		$this->data[$this->alias]['user_id'] = CakeSession::read('Auth.User.id');
+		$this->data[$this->alias]['session_data'] = json_encode(CakeSession::read());
 		return true;
 	}
 	

--- a/View/Logs/admin_index.ctp
+++ b/View/Logs/admin_index.ctp
@@ -1,34 +1,43 @@
 <?php echo $this->Html->css('/database_logger/css/style'); ?>
 <div class="database_logger_plugin">
-	<?php echo $this->element('admin_filter', array('plugin' => 'database_logger', 'model' => 'Log')); ?>
-	<div class="logs index">
-		<h2><?php echo __('Logs');?></h2>
-		<table cellpadding="0" cellspacing="0">
-		<tr>
-				<th><?php echo $this->Paginator->sort('created');?></th>
-				<th><?php echo $this->Paginator->sort('type');?></th>
-				<th><?php echo $this->Paginator->sort('message');?></th>
-				<th class="actions"><?php echo __('Actions');?></th>
-		</tr>
-		<?php
-		$i = 0;
-		foreach ($logs as $log):
-			$class = null;
-			if ($i++ % 2 == 0) {
-				$class = ' class="altrow"';
-			}
-		?>
-		<tr<?php echo $class;?>>
-			<td><?php echo $this->Time->niceShort($log['Log']['created']); ?>&nbsp;</td>
-			<td><?php echo $log['Log']['type']; ?>&nbsp;</td>
-			<td><?php echo $log['Log']['message']; ?>&nbsp;</td>
-			<td class="actions">
-				<?php echo $this->Html->link(__('View Details'), array('action' => 'view', $log['Log']['id'])); ?>
-				<?php echo $this->Html->link(__('Delete'), array('action' => 'delete', $log['Log']['id']), null, sprintf(__('Are you sure you want to delete this log # %s?'), $log['Log']['id'])); ?>
-			</td>
-		</tr>
-	<?php endforeach; ?>
-		</table>
-		<?php echo $this->element('paging', array('plugin' => 'database_logger')); ?>
-	</div>
+    <?php echo $this->element('admin_filter', ['plugin' => 'database_logger', 'model' => 'Log']); ?>
+    <div class="logs index">
+        <h2><?php echo __('Logs'); ?></h2>
+        <table cellpadding="0" cellspacing="0">
+            <tr>
+                <th><?php echo $this->Paginator->sort('created'); ?></th>
+                <th><?php echo $this->Paginator->sort('type'); ?></th>
+                <th><?php echo $this->Paginator->sort('message'); ?></th>
+                <th><?php echo $this->Paginator->sort('user_id'); ?></th>
+                <th class="actions"><?php echo __('Actions'); ?></th>
+            </tr>
+            <?php
+                $i = 0;
+                foreach ($logs as $log):
+                    $class = null;
+                    if ($i++ % 2 == 0) {
+                        $class = ' class="altrow"';
+                    }
+                    ?>
+                    <tr<?php echo $class; ?>>
+                        <td><?php echo $this->Time->niceShort($log['Log']['created']); ?>&nbsp;</td>
+                        <td><?php echo $log['Log']['type']; ?>&nbsp;</td>
+                        <td><?php echo $log['Log']['message']; ?>&nbsp;</td>
+                        <td><?php echo $log['Log']['user_id']; ?>&nbsp;</td>
+                        <td class="actions">
+                            <?php echo $this->Html->link(__('View Details'),
+                                    ['action' => 'view', $log['Log']['id']]); ?>
+                            <?php echo $this->Html->link(__('Delete'), ['action' => 'delete', $log['Log']['id']], null,
+                                    sprintf(__('Are you sure you want to delete this log # %s?'),
+                                            $log['Log']['id'])); ?>
+                            <?php echo $this->Html->link(__('Delete Similar'),
+                                    ['action' => 'delete_similar', $log['Log']['id']],
+                                    null,
+                                    sprintf(__('Are you sure you want to delete ALL logs similar to this?'))); ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+        </table>
+        <?php echo $this->element('paging', ['plugin' => 'database_logger']); ?>
+    </div>
 </div>

--- a/View/Logs/admin_view.ctp
+++ b/View/Logs/admin_view.ctp
@@ -43,6 +43,16 @@
 				<?php echo $log['Log']['created']; ?>
 				&nbsp;
 			</dd>
+            <dt<?php if ($i % 2 == 0) echo $class;?>><?php echo __('UserID'); ?></dt>
+            <dd<?php if ($i++ % 2 == 0) echo $class;?>>
+                <?php echo $log['Log']['user_id']; ?>
+                &nbsp;
+            </dd>
+            <dt<?php if ($i % 2 == 0) echo $class;?>><?php echo __('Session Data'); ?></dt>
+            <dd<?php if ($i++ % 2 == 0) echo $class;?>>
+                <?php echo print_r(json_decode($log['Log']['session_data'])); ?>
+                &nbsp;
+            </dd>
 		</dl>
 	</div>
 </div>


### PR DESCRIPTION
I added the ability to track user ID of the users that generate the logs. Imagine you are offering support for a system that has many entries in the error logs. If a User says that he is getting an error, you could easily filter ther logs by userID and solve the error.

I also added a button to delete all simillar logs. Imagine an Image that doesn't exists and generate thousends of entries in the error logs. With this Delete Similar button you can delete all the logs for that image, after solving the error.

Additionaly, in my project, i like to have session data in the logs, for debbugging purposes.

Elisio Leonardo (backstageel)
